### PR TITLE
Add support for *args and **kwargs and also dataclasses

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ jobs:
       # fail it if doesn't conform to black
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - uses: psf/black@stable
           with:
             options: "--check --verbose"
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -11,6 +11,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
@@ -32,13 +32,13 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_TEST_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
 
     - name: Install from testpypi and import
       run: |
-        i=0
-        while [ $i -lt 12 ] && [ "${{ github.ref_name }}" != $(pip index versions -i https://test.pypi.org/simple --pre valimp | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
-          do echo "waiting for package to appear in test index, i is $i, sleeping 5s"; sleep 5s; echo "woken up"; ((i++)); echo "next i is $i"; done
+        sleep 5
+        while [ "${{ github.ref_name }}" != $(pip index versions -i https://test.pypi.org/simple --pre valimp | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
+          do echo "waiting for package to appear in test index, sleeping 5s"; sleep 5s; echo "woken up"; done
         pip install --index-url https://test.pypi.org/simple valimp==${{ github.ref_name }} --no-deps
         pip install -r requirements.txt
         python -c 'import valimp;print(valimp.__version__)'
@@ -56,8 +56,8 @@ jobs:
 
     - name: Install and import
       run: |
-        i=0
-        while [ $i -lt 12 ] && [ "${{ github.ref_name }}" != $(pip index versions -i https://pypi.org/simple --pre valimp | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
-          do echo "waiting for package to appear in index, i is $i, sleeping 5s"; sleep 5s; echo "woken up"; ((i++)); echo "next i is $i"; done
+        sleep 5
+        while [ "${{ github.ref_name }}" != $(pip index versions -i https://pypi.org/simple --pre valimp | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
+          do echo "waiting for package to appear in index, sleeping 5s"; sleep 5s; echo "woken up"; done
         pip install --index-url https://pypi.org/simple valimp==${{ github.ref_name }}
         python -c 'import valimp;print(valimp.__version__)'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.2.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -13,7 +13,7 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-docstrings]

--- a/.pylintrc
+++ b/.pylintrc
@@ -23,7 +23,7 @@
 # usually to register additional checkers.
 load-plugins=pylint.extensions.broad_try_clause,
              pylint.extensions.confusing_elif,
-             pylint.extensions.comparetozero,
+        ;      pylint.extensions.comparetozero,  ; as of Nov 23 fails to load 
              pylint.extensions.bad_builtin,
              pylint.extensions.mccabe,
              pylint.extensions.docstyle,

--- a/docs/tutorials/tutorial.ipynb
+++ b/docs/tutorials/tutorial.ipynb
@@ -25,6 +25,7 @@
     "        - [Nested containers](#Nested-containers)\n",
     "    - [`collections.abc.Callable`](#collections.abc.Callable)\n",
     "    - [`typing.Literal`](#typing.Literal)\n",
+    "    - [*args and **kwargs](#*args-and-**kwargs)\n",
     "- [Signature validation](#Signature-validation)\n",
     "- [Coerce](#Coerce)\n",
     "    - [Type checkers](#Type-checkers)\n",
@@ -187,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "659899bb-86af-49f3-aa96-182ad63d5418",
    "metadata": {},
    "outputs": [],
@@ -252,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "2819abf2-a4a3-4125-8802-5f1f81700ed6",
    "metadata": {},
    "outputs": [
@@ -262,7 +263,7 @@
        "{'a': 'a string', 'b': 4}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -302,7 +303,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[5], line 2\n",
+    "Cell In[7], line 2\n",
     "      1 # invalid inputs...\n",
     "----> 2 ADataclass([\"I'm\", \"a\", \"list\"], b=4.0)\n",
     "\n",
@@ -338,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "ffbcfe86-686a-4bc4-b285-e57a202b8dd7",
    "metadata": {},
    "outputs": [],
@@ -386,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "9ce5f4a7-656e-44ff-9854-38cf687be2fd",
    "metadata": {},
    "outputs": [],
@@ -417,7 +418,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[8], line 1\n",
+    "Cell In[11], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -450,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "ccc170e7-22fb-4d40-bc04-653848249f69",
    "metadata": {},
    "outputs": [],
@@ -470,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "22cd31c0-abdf-4051-8914-bd1c1b66ea02",
    "metadata": {},
    "outputs": [],
@@ -509,7 +510,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[11], line 1\n",
+    "Cell In[14], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -545,7 +546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "3631a73a-0bd5-4780-b0d8-6d6ceab98ac8",
    "metadata": {},
    "outputs": [],
@@ -565,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "f6849283-06e9-41de-830a-93211c58d165",
    "metadata": {},
    "outputs": [],
@@ -604,7 +605,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[14], line 1\n",
+    "Cell In[17], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -641,7 +642,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "efc80de9-e69c-4518-a394-c50e84d9ac23",
    "metadata": {},
    "outputs": [],
@@ -662,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "b79ccb44-173c-46ca-ad3b-dc81322637c0",
    "metadata": {},
    "outputs": [],
@@ -707,7 +708,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[17], line 1\n",
+    "Cell In[20], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -747,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "6433ad69-214b-489c-8dd3-b02c8cf4156f",
    "metadata": {},
    "outputs": [],
@@ -793,7 +794,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[19], line 1\n",
+    "Cell In[22], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -822,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "b38c3307-6fbe-4fb8-ba75-16a1955cc2a8",
    "metadata": {},
    "outputs": [],
@@ -867,7 +868,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[21], line 1\n",
+    "Cell In[24], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -895,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "id": "c5159fb4-bb68-445b-ba45-07509458d305",
    "metadata": {},
    "outputs": [],
@@ -949,7 +950,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[23], line 1\n",
+    "Cell In[26], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -991,7 +992,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[24], line 1\n",
+    "Cell In[27], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -1011,7 +1012,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "id": "ed78b4bd-4196-4268-b19f-5afd02b89826",
    "metadata": {},
    "outputs": [],
@@ -1025,7 +1026,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "id": "6edc0fb2-75b7-4d7d-b7c2-12ff6cada321",
    "metadata": {},
    "outputs": [
@@ -1035,7 +1036,7 @@
        "([{0, 0.1}, {1, 1.1, 'one'}, 'not a set'], 'not a list')"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1062,7 +1063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "id": "f09f1647-4059-4e31-8513-3d1aa81892f2",
    "metadata": {},
    "outputs": [
@@ -1072,7 +1073,7 @@
        "(\"I'm a tuple\", 1, 2.0)"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1103,7 +1104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "44232c3f-b399-492b-a66c-1ab4ce983cc2",
    "metadata": {},
    "outputs": [],
@@ -1152,7 +1153,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[29], line 1\n",
+    "Cell In[32], line 1\n",
     "----> 1 pf(3, \"can't call me\", some_func, some_func)\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -1179,7 +1180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "id": "f9041474-ec0a-4488-8e80-ddcbbcbe6069",
    "metadata": {},
    "outputs": [],
@@ -1233,7 +1234,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[31], line 1\n",
+    "Cell In[34], line 1\n",
     "----> 1 pf(\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -1262,7 +1263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
    "id": "c6162215-5749-4be5-a8d2-683ac53748f0",
    "metadata": {},
    "outputs": [],
@@ -1291,7 +1292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 36,
    "id": "12a4aca1-005f-469c-b895-e8473ac50e86",
    "metadata": {},
    "outputs": [
@@ -1301,7 +1302,7 @@
        "'spam'"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1322,7 +1323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 37,
    "id": "bb10d385-cf0e-412f-ae74-2a98aa6aea95",
    "metadata": {},
    "outputs": [],
@@ -1356,13 +1357,201 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[35], line 1\n",
+    "Cell In[38], line 1\n",
     "----> 1 pf(diff_obj, diff_obj)\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
     "\n",
     "b\n",
     "\tTakes a literal from <('spam',)> although received 'spam'.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73da11d1-f9af-43b2-9e82-850b4ee77965",
+   "metadata": {},
+   "source": [
+    "### *args and **kwargs\n",
+    "\n",
+    "Valimp supports packing arguments to collect excess received positional and keyword arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "50470b59-5421-4036-8c93-d80624bac11d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@parse\n",
+    "def pf(\n",
+    "    a: int,\n",
+    "    *args,\n",
+    "    kw_a: bool,\n",
+    "    **kwargs\n",
+    "):\n",
+    "    return a, args, kw_a, kwargs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "a56eb1f1-14d7-41d7-8b40-23c54f73b88a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, (4, 5.0, 'six'), False, {'kw_extra0': 'extra0', 'kw_extra1': [1, 1]})"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pf(3, 4, 5.0, \"six\", kw_a=False, kw_extra0=\"extra0\", kw_extra1=[1, 1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d95486f8-2f58-4682-9b8a-41f8f2d96cc5",
+   "metadata": {},
+   "source": [
+    "Both *args and **kwargs can be validated against a type annotation. **NB** the type annotation should describe each item contained within the container, not the container object itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "e9dead85-ba39-425f-9858-9565230e2a1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@parse\n",
+    "def pf(\n",
+    "    a: int,\n",
+    "    *args: Union[int, float],\n",
+    "    kw_a: bool,\n",
+    "    **kwargs: bool,\n",
+    "):\n",
+    "    return a, args, kw_a, kwargs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "6880feb1-5e76-430a-9bee-24ad32ff85bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, (4, 5.0), False, {'kw_b': True, 'kw_c': False})"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# valid inputs\n",
+    "pf(3, 4, 5.0, kw_a=False, kw_b=True, kw_c=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f620337-a8d6-439c-bf23-3e1ccdb72208",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# invalid inputs\n",
+    "pf(3, 4, 5.0, \"six\", kw_a=False, kw_extra0=True, kw_extra1=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce1d479b-6e89-423b-84ea-29cd5663c9f3",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "---------------------------------------------------------------------------\n",
+    "InputsError                               Traceback (most recent call last)\n",
+    "Cell In[43], line 2\n",
+    "      1 # invalid inputs\n",
+    "----> 2 pf(3, 4, 5.0, \"six\", kw_a=False, kw_extra0=True, kw_extra1=2)\n",
+    "\n",
+    "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
+    "\n",
+    "_args2\n",
+    "\tTakes input that conforms with <(<class 'int'>, <class 'float'>)> although received 'six' of type <class 'str'>.\n",
+    "\n",
+    "kw_extra1\n",
+    "\tTakes type <class 'bool'> although received '2' of type <class 'int'>.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdc8fdd5-d8d4-4cc4-bbad-02fb9b1ee62f",
+   "metadata": {},
+   "source": [
+    "NB that in error message any invalid excess position arguments are named as the packing argument prefixed with a '_' and suffixed with the 0-indexed position of the argument within the container ('_args2' above).\n",
+    "\n",
+    "The packing arguments can be named unconventionally..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "1eca3fca-eef8-425d-998d-d0deef4fc3ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@parse\n",
+    "def pf(\n",
+    "    a: int,\n",
+    "    *excess_pos_args: Union[int, float],\n",
+    "    kw_a: bool,\n",
+    "    **excess_other: bool,\n",
+    "):\n",
+    "    return a, args, kw_a, kwargs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a5f7da2-83ee-4a0c-a6b0-b030a7e84ce1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# invalid inputs\n",
+    "pf(3, 4, 5.0, \"six\", kw_a=False, kw_extra0=True, kw_extra1=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "416367d0-1d58-4b68-938f-4d356a89bac4",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "---------------------------------------------------------------------------\n",
+    "InputsError                               Traceback (most recent call last)\n",
+    "Cell In[45], line 2\n",
+    "      1 # invalid inputs\n",
+    "----> 2 pf(3, 4, 5.0, \"six\", kw_a=False, kw_extra0=True, kw_extra1=2)\n",
+    "\n",
+    "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
+    "\n",
+    "_excess_pos_args2\n",
+    "\tTakes input that conforms with <(<class 'int'>, <class 'float'>)> although received 'six' of type <class 'str'>.\n",
+    "\n",
+    "kw_extra1\n",
+    "\tTakes type <class 'bool'> although received '2' of type <class 'int'>.\n",
     "```"
    ]
   },
@@ -1387,7 +1576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 46,
    "id": "eff9ce77-2c87-40ca-81c9-4faa54be0997",
    "metadata": {},
    "outputs": [],
@@ -1420,7 +1609,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[37], line 1\n",
+    "Cell In[47], line 1\n",
     "----> 1 pf(3, \"not an int\", 5, a=3, not_a_kwarg=3)\n",
     "\n",
     "InputsError: Inputs to 'pf' do not conform with the function signature:\n",
@@ -1459,7 +1648,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[38], line 1\n",
+    "Cell In[48], line 1\n",
     "----> 1 pf(3, kw_a=3)\n",
     "\n",
     "InputsError: Inputs to 'pf' do not conform with the function signature:\n",
@@ -1484,7 +1673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 49,
    "id": "aa10cb66-5db5-425a-ba4e-fad8e7e8d3eb",
    "metadata": {},
    "outputs": [],
@@ -1498,29 +1687,35 @@
     "    c: Annotated[Union[float, int, str], Coerce(float)],\n",
     "    d: Annotated[Union[float, int, str], Coerce(float)],\n",
     "    e: Annotated[Union[float, int, str, None], Coerce(float)],\n",
+    "    *args: Annotated[Union[float, int, str, None], Coerce(float)],\n",
     ") -> dict[str, Optional[float]]:\n",
-    "    return {\"a\":a, \"b\":b, \"c\":c, \"d\":d, \"e\":e}"
+    "    return {\"a\":a, \"b\":b, \"c\":c, \"d\":d, \"e\":e, \"args\": args}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 50,
    "id": "8aba30cd-bf06-4b86-b9fd-958bb226d29f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'a': 0.0, 'b': 1.1, 'c': 2.0, 'd': 3.3, 'e': None}"
+       "{'a': 0.0,\n",
+       " 'b': 1.1,\n",
+       " 'c': 2.0,\n",
+       " 'd': 3.3,\n",
+       " 'e': None,\n",
+       " 'args': (1.0, 2.0, 3.3, None)}"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pf(0, 1.1, '2', '3.3', None) "
+    "pf(0, 1.1, '2', '3.3', None, 1, 2.0, \"3.3\", None) "
    ]
   },
   {
@@ -1528,7 +1723,7 @@
    "id": "eda48990-ad81-4cd0-94cf-6ec2d0db6928",
    "metadata": {},
    "source": [
-    "Note that Valimp will not try to coerce a `None` input.\n",
+    "Note that Valimp will **not** try to coerce a `None` input.\n",
     "\n",
     "### Type checkers\n",
     "If you're using a type checker it's unlikely that it'll work out that the `@parse` decorator has coerced the input to a specific type. Hence, in the above example the checker will expect that the input could still be a string and will start advising of errors when the received object is treated as a float.\n",
@@ -1545,18 +1740,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "id": "1d69c27a-69e8-4f6d-93de-fb72d1ca9e7d",
+   "id": "093dbece-5d81-4760-b248-2c0e68b40417",
    "metadata": {},
    "source": [
-    "## Parsing"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c0190863-4a3f-4bee-86ad-a605cc86ef48",
-   "metadata": {},
-   "source": [
+    "## Parsing\n",
+    "\n",
     "Valimp also provides for abstracting away the parsing and/or custom validation of inputs.\n",
     "\n",
     "This is done by including an instance of `valimp.Parser` to the metadata of a parameter's annotation. The first argument of `Parser` takes a callable which should return the object as to be receieved by the decorated funcion's formal parameter. The callable should have the following signature:\n",
@@ -1593,7 +1783,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 51,
    "id": "872b9027-3aff-4901-859b-f8b1163b5a54",
    "metadata": {},
    "outputs": [
@@ -1603,7 +1793,7 @@
        "{'a': 'input_a', 'b': 'input_b_suffix'}"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1634,17 +1824,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 52,
    "id": "3639b3c6-eb1f-493c-a62c-47b36e460fcb",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'a': 'input_a', 'b': 'input_b_b', 'c': 'input_c_input_a'}"
+       "{'a': 'input_a',\n",
+       " 'b': 'input_b_b',\n",
+       " 'c': 'input_c_input_a',\n",
+       " 'kw_a': \"I'm a kwarg_kw_a\",\n",
+       " 'kwargs': {'kw_xtra': \"I'm kw_xtra_kw_xtra\"}}"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1664,11 +1858,14 @@
     "def pf(\n",
     "    a: str,\n",
     "    b: Annotated[str, my_parser],  # passes a reusable Parser\n",
-    "    c: Annotated[str, Parser(concat_earlier_input)],  \n",
+    "    c: Annotated[str, Parser(concat_earlier_input)],\n",
+    "    *,\n",
+    "    kw_a: Annotated[str, my_parser],\n",
+    "    **kwargs: Annotated[str, my_parser],\n",
     ") -> dict[str, str]:\n",
-    "    return {\"a\":a, \"b\":b, \"c\":c}\n",
+    "    return {\"a\":a, \"b\":b, \"c\":c, \"kw_a\":kw_a, \"kwargs\":kwargs}\n",
     "\n",
-    "pf(\"input_a\", \"input_b\", \"input_c\")"
+    "pf(\"input_a\", \"input_b\", \"input_c\", kw_a=\"I'm a kwarg\", kw_xtra=\"I'm kw_xtra\")"
    ]
   },
   {
@@ -1699,7 +1896,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "InputsError                               Traceback (most recent call last)\n",
-    "Cell In[43], line 1\n",
+    "Cell In[53], line 1\n",
     "----> 1 pf(\"valid\", \"valid\", 3)\n",
     "\n",
     "InputsError: The following inputs to 'pf' do not conform with the corresponding type annotation:\n",
@@ -1723,7 +1920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 54,
    "id": "aa1c9d23-908c-4b07-a5b1-59bc043c6d7c",
    "metadata": {},
    "outputs": [],
@@ -1805,7 +2002,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "ValueError                                Traceback (most recent call last)\n",
-    "Cell In[46], line 1\n",
+    "Cell In[56], line 1\n",
     "----> 1 pf(10, 4)\n",
     "\n",
     "ValueError: The value of parameter 'b' cannot be less than the value of parameter 'a', although received 'a' as 10 and 'b' as 4.\n",
@@ -1826,7 +2023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 57,
    "id": "bf0921b4-a961-450e-b719-f7bdea866c66",
    "metadata": {},
    "outputs": [],
@@ -1844,7 +2041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 58,
    "id": "2e85bfd6-05c9-48c1-ada4-82f684476311",
    "metadata": {},
    "outputs": [
@@ -1854,7 +2051,7 @@
        "(10, 10)"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1876,7 +2073,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 59,
    "id": "5e8d4eba-bcf8-4c11-978a-49dcba926250",
    "metadata": {},
    "outputs": [],
@@ -1893,7 +2090,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 60,
    "id": "4c50f083-b166-4a62-bb13-5ceec8ddca81",
    "metadata": {},
    "outputs": [
@@ -1903,7 +2100,7 @@
        "8"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1914,7 +2111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 61,
    "id": "05f9433c-64af-48b3-bb70-80cbcec9c03d",
    "metadata": {},
    "outputs": [],
@@ -1932,7 +2129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 62,
    "id": "7f00520f-0c4f-48e1-8f65-fd4cde8c2202",
    "metadata": {},
    "outputs": [],
@@ -1965,7 +2162,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "TypeError                                 Traceback (most recent call last)\n",
-    "Cell In[53], line 1\n",
+    "Cell In[63], line 1\n",
     "----> 1 pf(None)\n",
     "\n",
     "File ~\\valimp\\src\\valimp\\valimp.py:931, in parse.<locals>.wrapped_f(*args, **kwargs)\n",
@@ -2011,7 +2208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 64,
    "id": "0171f026-b3d0-434c-bd19-118a829c07a3",
    "metadata": {},
    "outputs": [],
@@ -2041,7 +2238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 65,
    "id": "b5fc576a-1c65-467c-bbb2-a67b412d3297",
    "metadata": {},
    "outputs": [
@@ -2051,7 +2248,7 @@
        "(2.2, None)"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2062,7 +2259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 66,
    "id": "e05c6d24-60a5-4ec1-9e1b-b98f9f8ee094",
    "metadata": {},
    "outputs": [
@@ -2072,7 +2269,7 @@
        "(2.2, 3.3)"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2083,7 +2280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 67,
    "id": "78cc5f4e-ac44-42bb-ada0-106dd023803f",
    "metadata": {},
    "outputs": [
@@ -2093,7 +2290,7 @@
        "(2.2, 3.0)"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2120,7 +2317,7 @@
     "```\n",
     "---------------------------------------------------------------------------\n",
     "ValueError                                Traceback (most recent call last)\n",
-    "Cell In[58], line 1\n",
+    "Cell In[68], line 1\n",
     "----> 1 pf(\"2.2\", \"1.8\")\n",
     "\n",
     "File ~\\valimp\\src\\valimp\\valimp.py:931, in parse.<locals>.wrapped_f(*args, **kwargs)\n",
@@ -2130,7 +2327,7 @@
     "    933     new_as_kwargs[name] = obj\n",
     "    935 return f(**new_as_kwargs)\n",
     "\n",
-    "Cell In[54], line 3, in _validate(name, obj, params)\n",
+    "Cell In[64], line 3, in _validate(name, obj, params)\n",
     "      1 def _validate(name: str, obj: float, params: dict[str: Any]) -> float:\n",
     "      2     if obj < params[\"a\"]:\n",
     "----> 3         raise ValueError(\n",

--- a/docs/tutorials/tutorial.ipynb
+++ b/docs/tutorials/tutorial.ipynb
@@ -14,6 +14,7 @@
     "- [Type validation](#Type-validation)\n",
     "    - [Built-in and custom types](#Built-in-and-custom-types)\n",
     "    - [Methods](#Methods)\n",
+    "    - [Dataclasses](#Dataclasses)\n",
     "    - [Type unions and optional types (the `|` operator)](#Type-unions-and-optional-types-(the-|-operator))\n",
     "    - [Validation of container items](#Validation-of-container-items)\n",
     "        - [`list`](#list-and-collections.abc.Sequence) and [`collections.abc.Sequence`](#list-and-collections.abc.Sequence)\n",
@@ -47,13 +48,15 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Valimp uses type annotations (hints) to easily validate, parse and coerce inputs to public functions and methods.\n",
+    "Valimp uses type annotations (hints) to easily validate, parse and coerce inputs to public functions, methods and dataclasses.\n",
     "\n",
     "Adding the `valimp.parse` decorator to a 'type-annotated' function or method will:\n",
     "  - validate all inputs against the type annotation, including optional type validation of items in containers.\n",
     "  - validate inputs against the function signature.\n",
     "  - provide for coercing inputs to a specific type.\n",
-    "  - provide for user-defined parsing and custom validation."
+    "  - provide for user-defined parsing and custom validation.\n",
+    "\n",
+    "The same functionality is available to a 'type-annotated' `dataclasses.dataclass` by adding the `valimp.parse_cls` decorator above the dataclass decorator."
    ]
   },
   {
@@ -184,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "659899bb-86af-49f3-aa96-182ad63d5418",
    "metadata": {},
    "outputs": [],
@@ -212,6 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# invalid inputs...\n",
     "sc.public_method(0, kw_a=None)"
    ]
   },
@@ -238,10 +242,86 @@
   },
   {
    "cell_type": "markdown",
+   "id": "330c9181-de60-43e2-aebf-3f29550486bb",
+   "metadata": {},
+   "source": [
+    "### Dataclasses\n",
+    "\n",
+    "And the same functionality is available to dataclasses by using the `@parse_cls` decorator..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2819abf2-a4a3-4125-8802-5f1f81700ed6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'a': 'a string', 'b': 4}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from valimp import parse_cls\n",
+    "import dataclasses\n",
+    "\n",
+    "@parse_cls\n",
+    "@dataclasses.dataclass\n",
+    "class ADataclass:\n",
+    "    \n",
+    "    a: str\n",
+    "    b: MyCustomType\n",
+    "\n",
+    "# valid inputs...\n",
+    "data = ADataclass(\"a string\", b=MyCustomType(4))\n",
+    "dataclasses.asdict(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8021e92d-e697-4826-8027-31d0f23a77ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# invalid inputs...\n",
+    "ADataclass([\"I'm\", \"a\", \"list\"], b=4.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df896d3f-bcc2-447a-b5b7-07bc7fa73bef",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "---------------------------------------------------------------------------\n",
+    "InputsError                               Traceback (most recent call last)\n",
+    "Cell In[5], line 2\n",
+    "      1 # invalid inputs...\n",
+    "----> 2 ADataclass([\"I'm\", \"a\", \"list\"], b=4.0)\n",
+    "\n",
+    "InputsError: The following inputs to '__init__' do not conform with the corresponding type annotation:\n",
+    "\n",
+    "a\n",
+    "\tTakes type <class 'str'> although received '[\"I'm\", 'a', 'list']' of type <class 'list'>.\n",
+    "\n",
+    "b\n",
+    "\tTakes type <class '__main__.MyCustomType'> although received '4.0' of type <class 'float'>.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0ff51e9d-2fda-4de5-a2d0-2a934ef98045",
    "metadata": {},
    "source": [
-    "Henceforth all examples in this tutorial will be defined as functions, although everything works in the same way for methods."
+    "**NB** Henceforth all examples in this tutorial will be defined as functions, although everything works in the same way for methods and dataclasses."
    ]
   },
   {

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --extra=dev --output-file=requirements_dev.txt pyproject.toml
 #
-astroid==3.0.1
+astroid==3.0.3
     # via pylint
-black==23.11.0
+black==24.2.0
     # via valimp (pyproject.toml)
 build==1.0.3
     # via pip-tools
@@ -22,33 +22,33 @@ colorama==0.4.6
     #   click
     #   pylint
     #   pytest
-dill==0.3.7
+dill==0.3.8
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 exceptiongroup==1.2.0
     # via pytest
 filelock==3.13.1
     # via virtualenv
-flake8==6.1.0
+flake8==7.0.0
     # via
     #   flake8-docstrings
     #   valimp (pyproject.toml)
 flake8-docstrings==1.7.0
     # via valimp (pyproject.toml)
-identify==2.5.32
+identify==2.5.34
     # via pre-commit
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via build
 iniconfig==2.0.0
     # via pytest
-isort==5.12.0
+isort==5.13.2
     # via pylint
 mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-mypy==1.7.1
+mypy==1.8.0
     # via valimp (pyproject.toml)
 mypy-extensions==1.0.0
     # via
@@ -61,30 +61,32 @@ packaging==23.2
     #   black
     #   build
     #   pytest
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pip-tools==7.3.0
+pip-tools==7.4.0
     # via valimp (pyproject.toml)
-platformdirs==4.0.0
+platformdirs==4.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-pre-commit==3.5.0
+pre-commit==3.6.1
     # via valimp (pyproject.toml)
 pycodestyle==2.11.1
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via flake8
-pylint==3.0.2
+pylint==3.0.3
     # via valimp (pyproject.toml)
 pyproject-hooks==1.0.0
-    # via build
-pytest==7.4.3
+    # via
+    #   build
+    #   pip-tools
+pytest==8.0.1
     # via valimp (pyproject.toml)
 pyyaml==6.0.1
     # via pre-commit
@@ -101,15 +103,15 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.3
     # via pylint
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   astroid
     #   black
     #   mypy
     #   pylint
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=tests --output-file=requirements_tests.txt pyproject.toml
 #
-black==23.11.0
+black==24.2.0
     # via valimp (pyproject.toml)
 click==8.1.7
     # via black
@@ -14,7 +14,7 @@ colorama==0.4.6
     #   pytest
 exceptiongroup==1.2.0
     # via pytest
-flake8==6.1.0
+flake8==7.0.0
     # via
     #   flake8-docstrings
     #   valimp (pyproject.toml)
@@ -30,19 +30,19 @@ packaging==23.2
     # via
     #   black
     #   pytest
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==4.0.0
+platformdirs==4.2.0
     # via black
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
 pycodestyle==2.11.1
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via flake8
-pytest==7.4.3
+pytest==8.0.1
     # via valimp (pyproject.toml)
 snowballstemmer==2.2.0
     # via pydocstyle
@@ -50,5 +50,5 @@ tomli==2.0.1
     # via
     #   black
     #   pytest
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via black

--- a/src/valimp/valimp.py
+++ b/src/valimp/valimp.py
@@ -938,3 +938,28 @@ def parse(f) -> collections.abc.Callable:
         return f(**new_as_kwargs)
 
     return wrapped_f
+
+
+def parse_cls(cls):
+    """Decorate a class to parse the constructor's arguments.
+
+    Can be used to verify input to a `dataclasses.dataclass`. In the
+    following example the a and b parameters will be parsed in the same
+    manner as if the __init__ method were decorated with @parse:
+
+        from dataclasses import dataclass
+        from typing import Union
+        from valimp import parse_cls, Coerce
+
+        @parse_cls
+        @dataclass
+        class ADataCls:
+
+            a: str
+            b: Annotated[Union[str, int], Coerce(str)]
+
+    NB The @parse_cls decorator must be placed above the @dataclass
+    decorator.
+    """
+    cls.__init__ = parse(cls.__init__)
+    return cls


### PR DESCRIPTION
Adds support for packing arguments, e.g. *args and **kwargs. These packing arguments can be optionally typed to validate, coerce and parse any passed arguments that will be packed up.

Also adds `parse_cls` decorator to provide for validating, coercing and parsing input to a 'type-annotated' dataclass.

Tests, README and tutorial revised / extended to reflect changes.