### PR TITLE
Update dep mgmt skill to include uv update fallbacks

### DIFF
--- a/.agents/skills/dependencies-management/SKILL.md
+++ b/.agents/skills/dependencies-management/SKILL.md
@@ -14,14 +14,26 @@ Create a new branch (following the naming convention in @AGENTS.md).
 
 ### 2. Update the lock file and environment
 
+Update `uv`:
 ```bash
-uv self update
+uv self update --token $GITHUB_TOKEN
 ```
 
-**IMPORTANT: updating `uv` MUST NOT be skipped.** If the above command fails (e.g. due to a GitHub API rate limit), install the latest `uv` via an alternative method before proceeding:
+**IMPORTANT: updating `uv` MUST NOT be skipped.** If the above command fails (e.g. due to a GitHub API rate limit), try the following fallbacks in order until `uv --version` confirms the latest version is active on PATH:
+
+**Fallback 1 — official install script** (preferred; replaces PATH binary directly):
 
 ```bash
-pip install --upgrade uv  # fallback if uv self update fails
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env  # refresh current shell session
+uv --version                 # verify PATH binary is now updated
+```
+
+**Fallback 2 — pip** (use only if `curl` is unavailable):
+
+```bash
+pip install --user --upgrade uv
+uv --version   # check if PATH binary was updated
 ```
 
 Once `uv` is up to date, run:


### PR DESCRIPTION
Crafted with Claude

Updates Step 2 of the `dependencies-management` skill to make `uv` updates more robust:

- `uv self update` now passes `--token $GITHUB_TOKEN` to avoid GitHub API rate limits (degrades gracefully if the variable is unset).
- Documents an ordered fallback chain when self-update fails:
  1. **Official install script** (`curl -LsSf https://astral.sh/uv/install.sh | sh`) — preferred, replaces the PATH binary directly.
  2. **pip** (`pip install --user --upgrade uv`) — last resort when `curl` is unavailable; `--user` installs to `~/.local/bin/uv`, which is typically earlier in PATH than a system-wide binary.