### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.9", "3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 	"Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",

--- a/tests/test_valimp.py
+++ b/tests/test_valimp.py
@@ -25,6 +25,21 @@ import valimp as m
 # ruff: noqa: ARG001  # unused-function-argument.  Just the nature, want to test errors raised during parsing before args received, not interested in the args as received.
 # ruff: noqa: E501  # line-too-long
 
+# In Python 3.14+ repr(typing.Union[X, Y]) changed from "typing.Union[X, Y]" to "X | Y".
+_UNION_TYPE_REPRS = {
+    "str, int, set": "str | int | set",
+    "int, float": "int | float",
+}
+
+
+def _msg_re(msg: str) -> str:
+    pattern = re.escape(msg)
+    for type_args, pipe_repr in _UNION_TYPE_REPRS.items():
+        old = re.escape(f"typing.Union[{type_args}]")
+        new = f"(?:{old}|{re.escape(pipe_repr)})"
+        pattern = pattern.replace(old, new)
+    return pattern
+
 
 def test_decorator_wrapped():
     """Verify post-decoration function retains hints and docstring."""
@@ -1213,7 +1228,7 @@ def test_invalid_inputs_seq_items():
         )
 
 
-INVALID_MSG_TUPLE_ITEMS = re.escape(
+INVALID_MSG_TUPLE_ITEMS = _msg_re(
     """The following inputs to 'f' do not conform with the corresponding type annotation:
 
 a
@@ -1563,7 +1578,7 @@ def test_invalid_inputs_mapping_items():
         )
 
 
-INVALID_MSG_NEATED_ITEMS_0 = re.escape(
+INVALID_MSG_NEATED_ITEMS_0 = _msg_re(
     """The following inputs to 'f' do not conform with the corresponding type annotation:
 
 a
@@ -1571,7 +1586,7 @@ a
 )
 
 
-INVALID_MSG_NEATED_ITEMS_1 = re.escape(
+INVALID_MSG_NEATED_ITEMS_1 = _msg_re(
     """The following inputs to 'f' do not conform with the corresponding type annotation:
 
 a


### PR DESCRIPTION
Generated by Claude.

Add support for Python 3.14.
- Add `Programming Language :: Python :: 3.14` classifier to `pyproject.toml`
- Update CI matrix in `build-test.yml` to test Python 3.9 and 3.14 (replacing 3.13)
- Fix test suite for Python 3.14: `repr(typing.Union[X, Y])` changed from `"typing.Union[X, Y]"` to `"X | Y"` in Python 3.14, breaking three regex patterns. Added a `_msg_re()` helper that replaces each Union pattern with a non-capturing alternation (`(?:old|new)`) that matches both representations.