### PR TITLE
Honor PEP 484 numeric tower for `float` and `complex`

### DIFF
--- a/src/valimp/valimp.py
+++ b/src/valimp/valimp.py
@@ -97,6 +97,10 @@ Type validation
   - Inputs annoated with a typing.Literal type can be validated as either
   comparing equal (default) or being equal.
 
+  - In line with PEP 484 the numeric tower is honored, such that an input
+  of type int is acceptable where the annotation is float, and an input of
+  type int or float is acceptable where the annotation is complex.
+
 From Python 3.10 use of the | operator is supported to define annotations
 describing type unions and optional types.
 
@@ -455,6 +459,13 @@ def validates_against_hint(  # noqa: C901, PLR0911, PLR0912
     # a union defined with | operation from python 3.10
     if origin is None:
         if isinstance(obj, hint):
+            return VALIDATED
+        # PEP 484 numeric tower: an int is acceptable where a float is
+        # annotated, and an int or float is acceptable where a complex is
+        # annotated.
+        if hint is float and isinstance(obj, int):
+            return VALIDATED
+        if hint is complex and isinstance(obj, (int, float)):
             return VALIDATED
         if not rtrn_error:
             return FAILED_SIMPLE

--- a/src/valimp/valimp.py
+++ b/src/valimp/valimp.py
@@ -97,9 +97,9 @@ Type validation
   - Inputs annoated with a typing.Literal type can be validated as either
   comparing equal (default) or being equal.
 
-  - In line with PEP 484 the numeric tower is honored, such that an input
-  of type int is acceptable where the annotation is float, and an input of
-  type int or float is acceptable where the annotation is complex.
+  - The numeric tower is honored (PEP 484), such that an input of type int
+  is acceptable where the annotation is float, and an input of type int or
+  float is acceptable where the annotation is complex.
 
 From Python 3.10 use of the | operator is supported to define annotations
 describing type unions and optional types.
@@ -460,11 +460,11 @@ def validates_against_hint(  # noqa: C901, PLR0911, PLR0912
     if origin is None:
         if isinstance(obj, hint):
             return VALIDATED
-        # PEP 484 numeric tower: an int is acceptable where a float is
-        # annotated, and an int or float is acceptable where a complex is
-        # annotated.
+        # PEP 484 numeric tower: an int is acceptable where a float is annotated...
         if hint is float and isinstance(obj, int):
             return VALIDATED
+        # ... and an int or float is acceptable where a complex is annotated.
+        # annotated.
         if hint is complex and isinstance(obj, (int, float)):
             return VALIDATED
         if not rtrn_error:

--- a/tests/test_valimp.py
+++ b/tests/test_valimp.py
@@ -1932,25 +1932,24 @@ def test_unpacked():
 
 
 def test_numeric_tower():
-    """Verify PEP 484 numeric tower behavior for `float` and `complex`.
+    """Verify numeric tower behavior (PEP 484) for `float` and `complex`.
 
     A parameter annotated as `float` should accept an `int` value, and a
     parameter annotated as `complex` should accept an `int` or `float`
     value (in line with the treatment afforded by static type checkers).
-
-    See https://github.com/maread99/valimp/issues/17.
     """
 
     @m.parse
     def f_float(a: float) -> float:
         return a
 
-    # int passed where float annotated - per PEP 484 numeric tower
+    # verify int passes a float annotation
     int_in = 3
     float_in = 3.5
     assert f_float(int_in) == int_in
     assert isinstance(f_float(int_in), int)  # not coerced, passed through
     assert f_float(float_in) == float_in
+    assert isinstance(f_float(float_in), float)
 
     # invalid - str not part of the numeric tower
     with pytest.raises(m.InputsError, match=r"Takes type <class 'float'>"):
@@ -1963,8 +1962,11 @@ def test_numeric_tower():
     # int and float passed where complex annotated
     complex_in = 3 + 2j
     assert f_complex(int_in) == int_in
+    assert isinstance(f_complex(int_in), int)  # not coerced, passed through
     assert f_complex(float_in) == float_in
+    assert isinstance(f_complex(float_in), float)  # not coerced, passed through
     assert f_complex(complex_in) == complex_in
+    assert isinstance(f_complex(complex_in), complex)
 
     # invalid - str not part of the numeric tower
     with pytest.raises(m.InputsError, match=r"Takes type <class 'complex'>"):
@@ -1972,12 +1974,12 @@ def test_numeric_tower():
 
     # verify that int -> float works for items in containers
     @m.parse
-    def f_container(
+    def f_containers(
         a: list[float],
         b: dict[str, float],
         c: tuple[float, ...],
         d: set[float],
-        e: tuple[float, float, complex],
+        e: tuple[float, float, complex, complex],
     ) -> tuple:
         return a, b, c, d, e
 
@@ -1985,8 +1987,8 @@ def test_numeric_tower():
     dict_in = {"x": 1, "y": 2.5}
     tuple_in = (1, 2, 3.0)
     set_in = {1, 2.0}
-    fixed_tuple_in = (1, 2.0, 3)
-    rtrn = f_container(list_in, dict_in, tuple_in, set_in, fixed_tuple_in)
+    fixed_tuple_in = (1, 2.0, 3, 1.5)
+    rtrn = f_containers(list_in, dict_in, tuple_in, set_in, fixed_tuple_in)
     assert rtrn == (list_in, dict_in, tuple_in, set_in, fixed_tuple_in)
 
     # verify int -> float works within a Union
@@ -2027,6 +2029,8 @@ def test_numeric_tower():
     assert f_int(int_in) == int_in
     with pytest.raises(m.InputsError, match=r"Takes type <class 'int'>"):
         f_int(float_in)
+    with pytest.raises(m.InputsError, match=r"Takes type <class 'int'>"):
+        f_int(complex_in)
 
     # nor should a complex be accepted where a float is annotated.
     with pytest.raises(m.InputsError, match=r"Takes type <class 'float'>"):

--- a/tests/test_valimp.py
+++ b/tests/test_valimp.py
@@ -1929,3 +1929,105 @@ def test_unpacked():
         kwargs_extra_expected,
     )
     assert f_annotated(*pos_args, *args_extra, **kwargs, **kwargs_extra) == expected
+
+
+def test_numeric_tower():
+    """Verify PEP 484 numeric tower behavior for `float` and `complex`.
+
+    A parameter annotated as `float` should accept an `int` value, and a
+    parameter annotated as `complex` should accept an `int` or `float`
+    value (in line with the treatment afforded by static type checkers).
+
+    See https://github.com/maread99/valimp/issues/17.
+    """
+
+    @m.parse
+    def f_float(a: float) -> float:
+        return a
+
+    # int passed where float annotated - per PEP 484 numeric tower
+    int_in = 3
+    float_in = 3.5
+    assert f_float(int_in) == int_in
+    assert isinstance(f_float(int_in), int)  # not coerced, passed through
+    assert f_float(float_in) == float_in
+
+    # invalid - str not part of the numeric tower
+    with pytest.raises(m.InputsError, match=r"Takes type <class 'float'>"):
+        f_float("3")
+
+    @m.parse
+    def f_complex(a: complex) -> complex:
+        return a
+
+    # int and float passed where complex annotated
+    complex_in = 3 + 2j
+    assert f_complex(int_in) == int_in
+    assert f_complex(float_in) == float_in
+    assert f_complex(complex_in) == complex_in
+
+    # invalid - str not part of the numeric tower
+    with pytest.raises(m.InputsError, match=r"Takes type <class 'complex'>"):
+        f_complex("3")
+
+    # verify that int -> float works for items in containers
+    @m.parse
+    def f_container(
+        a: list[float],
+        b: dict[str, float],
+        c: tuple[float, ...],
+        d: set[float],
+        e: tuple[float, float, complex],
+    ) -> tuple:
+        return a, b, c, d, e
+
+    list_in = [1, 2.0, 3]
+    dict_in = {"x": 1, "y": 2.5}
+    tuple_in = (1, 2, 3.0)
+    set_in = {1, 2.0}
+    fixed_tuple_in = (1, 2.0, 3)
+    rtrn = f_container(list_in, dict_in, tuple_in, set_in, fixed_tuple_in)
+    assert rtrn == (list_in, dict_in, tuple_in, set_in, fixed_tuple_in)
+
+    # verify int -> float works within a Union
+    @m.parse
+    def f_union(a: Union[float, str]) -> Union[float, str]:
+        return a
+
+    assert f_union(int_in) == int_in
+    assert f_union(float_in) == float_in
+    assert f_union("a") == "a"
+
+    # verify int -> float works with Optional
+    @m.parse
+    def f_optional(a: Optional[float] = None) -> Optional[float]:
+        return a
+
+    assert f_optional(int_in) == int_in
+    assert f_optional(float_in) == float_in
+    assert f_optional() is None
+    assert f_optional(None) is None
+
+    # verify int -> complex works within a Union
+    @m.parse
+    def f_complex_union(a: Union[complex, str]) -> Union[complex, str]:
+        return a
+
+    assert f_complex_union(int_in) == int_in
+    assert f_complex_union(float_in) == float_in
+    assert f_complex_union(complex_in) == complex_in
+    assert f_complex_union("a") == "a"
+
+    # verify that the numeric tower does NOT widen in the opposite direction:
+    # a float should not be accepted where an int is annotated.
+    @m.parse
+    def f_int(a: int) -> int:
+        return a
+
+    assert f_int(int_in) == int_in
+    with pytest.raises(m.InputsError, match=r"Takes type <class 'int'>"):
+        f_int(float_in)
+
+    # nor should a complex be accepted where a float is annotated.
+    with pytest.raises(m.InputsError, match=r"Takes type <class 'float'>"):
+        f_float(complex_in)


### PR DESCRIPTION
## Summary

Fixes #17.

In line with PEP 484's "numeric tower" — and the treatment afforded by static type checkers — a parameter annotated with `float` now accepts an `int` value, and a parameter annotated with `complex` accepts an `int` or `float` value.

Previously these inputs were rejected by `valimp` because validation used a plain `isinstance(obj, hint)` check, which made annotations like `float` or `complex` only accept values that were strictly instances of those exact types.

### Changes

- `src/valimp/valimp.py::validates_against_hint`: when the hint is a single type and `isinstance(obj, hint)` fails, additionally accept the input if `hint is float` and `obj` is an `int`, or if `hint is complex` and `obj` is an `int` or `float`. Because container item validation recurses through the same code path, the new behavior automatically applies to items in `list[float]`, `dict[str, float]`, `tuple[complex, ...]`, etc., and to elements of `Union`/`Optional` annotations.
- Documentation updated in the module docstring to note the behavior.
- Added `test_numeric_tower` to exercise:
  - `int` accepted where `float` is annotated (and value passed through, not coerced).
  - `int`/`float` accepted where `complex` is annotated.
  - The same widening applied for items inside containers (`list`, `dict`, `tuple`, `set`, and fixed-length `tuple`).
  - The same widening applied inside `Union` and `Optional`.
  - The widening does NOT apply in the opposite direction: a `float` is still rejected where `int` is annotated, and a `complex` is still rejected where `float` is annotated.
  - Non-numeric types (e.g. `str`) are still rejected.

## Test plan

- [x] `ruff check` and `ruff format --check` pass.
- [x] `pytest` passes locally on Python 3.9.
- [ ] CI passes on the full Python/OS matrix.


---
_Generated by [Claude Code](https://claude.ai/code/session_018AFyQHSenpNdj4CwTyJDzz)_